### PR TITLE
Add module import graph report

### DIFF
--- a/docs/module-imports.json
+++ b/docs/module-imports.json
@@ -1,0 +1,109 @@
+[
+  {
+    "file": "src/app.d.ts",
+    "imports": []
+  },
+  {
+    "file": "src/lib/auth.ts",
+    "imports": [
+      "$app/navigation",
+      "$lib/pb/pb",
+      "$lib/pb/pb-createPosition",
+      "$lib/types/pbTypes",
+      "$lib/types/pricesTypes"
+    ]
+  },
+  {
+    "file": "src/lib/components/AuthForm.svelte",
+    "imports": [
+      "$app/navigation",
+      "$lib/auth"
+    ]
+  },
+  {
+    "file": "src/lib/components/Table.svelte",
+    "imports": [
+      "$lib/pb/pb",
+      "$lib/positions.svelte",
+      "$lib/prices/priceSnapshot.svelte",
+      "$lib/statePosition.svelte",
+      "$lib/types/pricesTypes"
+    ]
+  },
+  {
+    "file": "src/lib/components/Transaction.svelte",
+    "imports": [
+      "$lib/positions.svelte",
+      "$lib/prices/priceSnapshot.svelte"
+    ]
+  },
+  {
+    "file": "src/lib/pb/pb-createPosition.ts",
+    "imports": [
+      "$lib/prices/types",
+      "pocketbase"
+    ]
+  },
+  {
+    "file": "src/lib/pb/pb.ts",
+    "imports": [
+      "pocketbase",
+      "svelte/store"
+    ]
+  },
+  {
+    "file": "src/lib/positions.svelte.ts",
+    "imports": [
+      "$lib/types/pricesTypes",
+      "pocketbase"
+    ]
+  },
+  {
+    "file": "src/lib/prices/priceSnapshot.svelte.ts",
+    "imports": [
+      "$lib/types/pricesTypes",
+      "pocketbase"
+    ]
+  },
+  {
+    "file": "src/lib/statePosition.svelte.ts",
+    "imports": [
+      "$lib/positions.svelte",
+      "pocketbase"
+    ]
+  },
+  {
+    "file": "src/lib/types/pbTypes.ts",
+    "imports": []
+  },
+  {
+    "file": "src/lib/types/pricesTypes.ts",
+    "imports": []
+  },
+  {
+    "file": "src/routes/+layout.svelte",
+    "imports": [
+      "$app/navigation",
+      "$app/stores",
+      "$lib/auth",
+      "$lib/pb/pb",
+      "../app.css"
+    ]
+  },
+  {
+    "file": "src/routes/+layout.ts",
+    "imports": []
+  },
+  {
+    "file": "src/routes/+page.svelte",
+    "imports": [
+      "$lib/components/Table.svelte"
+    ]
+  },
+  {
+    "file": "src/routes/auth/+page.svelte",
+    "imports": [
+      "$lib/components/AuthForm.svelte"
+    ]
+  }
+]

--- a/tools/list-imports.mjs
+++ b/tools/list-imports.mjs
@@ -1,0 +1,68 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT = path.resolve('src');
+
+const VALID_EXTENSIONS = new Set(['.js', '.ts', '.svelte']);
+
+/**
+ * Recursively collects files with valid extensions within a directory.
+ * @param {string} dir
+ * @returns {Promise<string[]>}
+ */
+async function collectFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return collectFiles(entryPath);
+      }
+      if (VALID_EXTENSIONS.has(path.extname(entry.name))) {
+        return entryPath;
+      }
+      return [];
+    })
+  );
+  return files.flat();
+}
+
+/**
+ * Extracts imported specifiers from the file contents.
+ * @param {string} contents
+ * @returns {string[]}
+ */
+function extractImports(contents) {
+  const matches = new Set();
+  const staticImportRegex = /(?:^|\n)\s*import\s+(?:[^'";]+?\s+from\s+)?["']([^"']+)["']/g;
+  const typeImportRegex = /(?:^|\n)\s*import\s+type\s+[^'";]+?from\s+["']([^"']+)["']/g;
+  const dynamicImportRegex = /import\(\s*["']([^"']+)["']\s*\)/g;
+
+  let match;
+  while ((match = staticImportRegex.exec(contents)) !== null) {
+    matches.add(match[1]);
+  }
+  while ((match = typeImportRegex.exec(contents)) !== null) {
+    matches.add(match[1]);
+  }
+  while ((match = dynamicImportRegex.exec(contents)) !== null) {
+    matches.add(match[1]);
+  }
+
+  return [...matches];
+}
+
+const relativePath = (filePath) => path.relative(process.cwd(), filePath);
+
+const graph = {};
+
+const files = await collectFiles(ROOT);
+for (const file of files) {
+  const contents = await readFile(file, 'utf8');
+  const imports = extractImports(contents);
+  graph[relativePath(file)] = imports;
+}
+
+const sortedKeys = Object.keys(graph).sort();
+const output = sortedKeys.map((key) => ({ file: key, imports: graph[key].sort() }));
+console.log(JSON.stringify(output, null, 2));


### PR DESCRIPTION
## Summary
- add a Node script that traverses the src tree and extracts module import statements
- generate a JSON report under docs/ with the resolved import relationships

## Testing
- node tools/list-imports.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e6534c7328832fb1a41fc9624ca8b7